### PR TITLE
Fix warning

### DIFF
--- a/src/sdl-instead/game.c
+++ b/src/sdl-instead/game.c
@@ -656,7 +656,7 @@ int game_restart(void)
 	}
 	return 0;
 }
-int static cur_vol = 0;
+static int cur_vol = 0;
 void free_last_music(void);
 
 void game_stop_mus(int ms)


### PR DESCRIPTION
Fix "/tmp/instead/src/sdl-instead/game.c:659: warning: 'static' is not at beginning of declaration" by gcc 4.2
