### PR TITLE
Fix realloc misusages

### DIFF
--- a/src/sdl-instead/graphics.c
+++ b/src/sdl-instead/graphics.c
@@ -1361,6 +1361,7 @@ static SDL_Rect **SDL_ListModes(const SDL_PixelFormat * format, Uint32 flags)
 	SDL_DisplayMode mode;    
 	int i, nmodes;
 	SDL_Rect **modes;
+	SDL_Rect **new_modes;
 	Uint32 Rmask, Gmask, Bmask, Amask;
 	int bpp;
 
@@ -1387,10 +1388,11 @@ static SDL_Rect **SDL_ListModes(const SDL_PixelFormat * format, Uint32 flags)
 			&& modes[nmodes - 1]->h == mode.h) {
 			continue;
 		}
-		modes = SDL_realloc(modes, (nmodes + 2) * sizeof(*modes));
-		if (!modes) {
+		new_modes = SDL_realloc(modes, (nmodes + 2) * sizeof(*modes));
+		if (!new_modes) {
 			return NULL;
 		}
+		modes = new_modes;
 		modes[nmodes] = (SDL_Rect *) SDL_malloc(sizeof(SDL_Rect));
 		if (!modes[nmodes]) {
 			return NULL;
@@ -2657,11 +2659,19 @@ struct xref *xref_new(char *link)
 	return p;
 }
 
-void xref_add_word(struct xref *xref, struct word *word)
+int xref_add_word(struct xref *xref, struct word *word)
 {
-	xref->words = realloc(xref->words, (xref->num + 1) * sizeof(struct word*));
+	struct word **new_words;
+
+	new_words = realloc(xref->words, (xref->num + 1) * sizeof(struct word*));
+	if (!new_words)
+		return -1;
+
+	xref->words = new_words;
 	xref->words[xref->num ++] = word;
 	word->xref = xref;
+
+	return 0;
 }
 
 void xref_free(struct xref *xref)

--- a/src/sdl-instead/menu.c
+++ b/src/sdl-instead/menu.c
@@ -860,6 +860,7 @@ int menu_langs_lookup(const char *path)
 	int n = 0, i = 0;
 	DIR *d;
 	struct dirent *de;
+	struct lang *new_langs;
 
 	if (!path)
 		return 0;
@@ -877,7 +878,12 @@ int menu_langs_lookup(const char *path)
 	if (!n)
 		goto out;
 
-	langs = realloc(langs, sizeof(struct lang) * (n + langs_nr));
+	new_langs = realloc(langs, sizeof(struct lang) * (n + langs_nr));
+	if (!new_langs) {
+		closedir(d);
+		return -1;
+	}
+	langs = new_langs;
 
 	while ((de = readdir(d)) && i < n) {
 		if (!is_lang(path, de->d_name))

--- a/src/sdl-instead/themes.c
+++ b/src/sdl-instead/themes.c
@@ -931,6 +931,7 @@ int themes_lookup(const char *path)
 	int n = 0, i = 0;
 	DIR *d;
 	struct dirent *de;
+	struct theme *new_themes;
 
 	if (!path)
 		return 0;
@@ -949,7 +950,12 @@ int themes_lookup(const char *path)
 	rewinddir(d);
 	if (!n)
 		goto out;
-	themes = realloc(themes, sizeof(struct theme) * (n + themes_nr));
+	new_themes = realloc(themes, sizeof(struct theme) * (n + themes_nr));
+	if (!new_themes) {
+		closedir(d);
+		return -1;
+	}
+	themes = new_themes;
 	while ((de = readdir(d)) && i < n) {
 		/*if (de->d_type != DT_DIR)
 			continue;*/


### PR DESCRIPTION
x = realloc(x) construct nullifies x in case of failure and causes a memleak
