### PR TITLE
Show error message if image's filename is wrong

### DIFF
--- a/src/sdl-instead/graphics.c
+++ b/src/sdl-instead/graphics.c
@@ -1192,8 +1192,17 @@ img_t gfx_load_image(char *filename)
 		img = _gfx_load_image(filename, 0);
 	if (!img)
 		img = _gfx_load_combined_image(filename);
-	if (!img)
+	if (!img){
+		const char preambule[] = "Can not load image: ";
+		const size_t pr_len = strlen(preambule);
+		const size_t fn_len = strlen(filename);
+		char* msg = calloc(pr_len + fn_len + 1, sizeof(char));
+		strcat(msg, preambule);
+		strcat(msg, filename);
 		fprintf(stderr, "Can not load image: '%s'\n", filename);
+		game_err_msg(msg);
+		free(msg);
+	}
 	return img;
 }
 


### PR DESCRIPTION
Теперь, если автор допустит ошибку в названии изображения (пути к нему), то получит соответствующее сообщение при запуске интерпретатора. 

Вся логика проверки в INSTEAD уже была - но он "молча" слал все в stderr, не прерываясь.

В качестве бонуса: в случае, если ошибка была допущена в theme.ini, то выскакивает не "Неизвестная ошибка", а эта, более понятная. 