### PR TITLE
Fix -Wimplicit-fallthrough warnings

### DIFF
--- a/src/SDL_gfxBlitFunc.h
+++ b/src/SDL_gfxBlitFunc.h
@@ -150,9 +150,9 @@ extern    "C" {
 #define GFX_DUFFS_LOOP4(pixel_copy_increment, width)			\
 	{ int n = (width+3)/4;							\
 	switch (width & 3) {						\
-	case 0: do {	pixel_copy_increment;				\
-	case 3:		pixel_copy_increment;				\
-	case 2:		pixel_copy_increment;				\
+	case 0: do {	pixel_copy_increment; /* fall through */	\
+	case 3:		pixel_copy_increment; /* fall through */	\
+	case 2:		pixel_copy_increment; /* fall through */	\
 	case 1:		pixel_copy_increment;				\
 	} while ( --n > 0 );					\
 	}								\

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -3564,6 +3564,7 @@ int gfx_get_token(const char *ptr, char **eptr, char **val, int *sp)
 	switch (*ptr) {
 	case 'y':
 		y_token = 1;
+		/* Fall through */
 	case 'x':
 		if (ptr[1] != ':')
 			return 0;

--- a/src/input.c
+++ b/src/input.c
@@ -288,6 +288,7 @@ int input(struct inp_event *inp, int wait)
 /*		case SDL_WINDOWEVENT_RESIZED: */
 		case SDL_WINDOWEVENT_SIZE_CHANGED:
 			gfx_resize(event.window.data1, event.window.data2);
+			/* Fall through */
 		case SDL_WINDOWEVENT_EXPOSED:
 			gfx_flip();
 			gfx_commit();

--- a/src/unix.c
+++ b/src/unix.c
@@ -147,8 +147,8 @@ char *open_file_dialog(void)
 	file[0] = 0;
 	file_dialog = gtk_file_chooser_dialog_new (BROWSE_MENU, 
 			NULL, GTK_FILE_CHOOSER_ACTION_OPEN,
-			GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-			GTK_STOCK_OPEN,   GTK_RESPONSE_ACCEPT, NULL);
+			"_Cancel", GTK_RESPONSE_CANCEL,
+			"_Open",   GTK_RESPONSE_ACCEPT, NULL);
 
 	if (old_dir_set)
 		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(file_dialog),


### PR DESCRIPTION
Make GCC 7.1.0 happy and provide "fall through" comments explicitly,
wherever we really don't want to break.

Signed-off-by: Sam Protsenko <joe.skb7@gmail.com>