### PR TITLE
Fix deprecated definitions in GTK3 code

### DIFF
--- a/src/unix.c
+++ b/src/unix.c
@@ -147,8 +147,8 @@ char *open_file_dialog(void)
 	file[0] = 0;
 	file_dialog = gtk_file_chooser_dialog_new (BROWSE_MENU, 
 			NULL, GTK_FILE_CHOOSER_ACTION_OPEN,
-			GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-			GTK_STOCK_OPEN,   GTK_RESPONSE_ACCEPT, NULL);
+			"_Cancel", GTK_RESPONSE_CANCEL,
+			"_Open",   GTK_RESPONSE_ACCEPT, NULL);
 
 	if (old_dir_set)
 		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(file_dialog),


### PR DESCRIPTION
GTK_STOCK_CANCEL and GTK_STOCK_OPEN are deprecated now: [1].

GCC issues next warning due to this:

    src/unix.c:150:4: warning: ‘GtkStock’ is deprecated
    [-Wdeprecated-declarations]
        GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
        ^~~~~~~~~~~~~~~~
    src/unix.c:151:4: warning: ‘GtkStock’ is deprecated
    [-Wdeprecated-declarations]
        GTK_STOCK_OPEN,   GTK_RESPONSE_ACCEPT, NULL);
        ^~~~~~~~~~~~~~

Replace GTK_STOCK_* definitions with preferred ones, according to
documentation [2].

Compared to documentation example, I have removed _() function
invocation, as we are not using "gettext" internationalization library.
So instead of _("_Cancel"), I've put only "_Cancel".

[1] https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html#GTK-STOCK-CANCEL:CAPS
[2] https://developer.gnome.org/gtk3/stable/GtkFileChooserDialog.html

Signed-off-by: Sam Protsenko <joe.skb7@gmail.com>