### PR TITLE
instead: Fix GCC compilation warning

### DIFF
--- a/src/instead/instead.c
+++ b/src/instead/instead.c
@@ -62,8 +62,16 @@ char 		*instead_fromgame(const char *s);
 char 		*togame(const char *s);
 lua_State	*L = NULL;
 
+/*
+ * Further we will use instead_api_path[] with additional subpaths appended.
+ * E.g. we will add "/stead.lua" part to it when building stead_path[] string.
+ * So we want to keep instead_api_path[] length less than PATH_MAX.
+ */
+#define INSTEAD_API_SUBPATH_MAX		10
+#define INSTEAD_API_PATH_MAX		(PATH_MAX - INSTEAD_API_SUBPATH_MAX)
+
 static char *err_msg = NULL;
-static char instead_api_path[PATH_MAX];
+static char instead_api_path[INSTEAD_API_PATH_MAX];
 
 static char *API = NULL;
 static char *MAIN = NULL;


### PR DESCRIPTION
When building INSTEAD using GCC 8.2 next warning message appears:

    warning: ‘/stead.lua’ directive output may be truncated writing 10 bytes
    into a region of size between 1 and 4096 [-Wformat-truncation=]

    snprintf(stead_path, sizeof(stead_path), "%s/stead.lua", STEAD_API_PATH);
                                              ^~~~~~~~~~

This happens because we are building stead_path[] from two strings:

    stead_path[PATH_MAX] = STEAD_PATH_API[PATH_MAX] + "/stead.lua"

Fix that warning by making sure that resulting stead_path[] string
length won't be more than PATH_MAX.

Signed-off-by: Sam Protsenko <joe.skb7@gmail.com>