### PR TITLE
travis: update to use liblua5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - CMAKE_FLAGS="-DSTANDALONE=TRUE"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq cmake libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev liblua5.1-0-dev libgtk2.0-dev libgtk-3-dev
+  - sudo apt-get install -qq cmake libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev liblua5.4-dev libgtk2.0-dev libgtk-3-dev
 script:
   - mkdir build
   - cd build


### PR DESCRIPTION
I am trying to [upgrade lua formula](https://github.com/Homebrew/homebrew-core/pull/57133) to 5.4.0, but found the instead actually does not quite work with the latest lua, so bump the liblua to 5.4 in here.
