### PR TITLE
Fix RTL menu and random alignment errors

### DIFF
--- a/src/graphics.c
+++ b/src/graphics.c
@@ -3034,23 +3034,29 @@ static int is_rtl(int direction) {
 	#endif
 }
 
+/* https://stackoverflow.com/a/32936928 */
+static size_t count_utf8_code_points(const char *s) {
+    size_t count = 0;
+    while (*s) {
+        count += (*s++ & 0xC0) != 0x80;
+    }
+    return count;
+}
+
 /* This function detects and configures direction, script and type of a word. */
 static void detect_direction(struct word *w, const char *str) {
 	#ifdef _USE_HARFBUZZ
 	uint32_t dest = 0;
-	uint32_t first[2];
-	u8_toucs(first, 2, str, u8_seqlen(str));
 	/*	Find the first alphanumeric utf8 character for a meaningful direction
 		or use direction of the first character.
 	*/
 	int index = 0;
-	int i = 0;
-	for (i=0; i<u8_strlen(str); i++) {
+	size_t i;
+	for (i=0; i<count_utf8_code_points(str); i++) {
 		dest = u8_nextchar(str, &index);
-		if (g_unichar_isalnum(dest))
+		if (g_unichar_isalpha(dest))
 			break;
 	}
-	dest = dest?dest:first[0];
 	/* Is this made of alphabets? */
 	w->isalpha = g_unichar_isalpha(dest);
 	switch(g_unichar_get_script(dest)) {

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -3036,11 +3036,11 @@ static int is_rtl(int direction) {
 
 /* https://stackoverflow.com/a/32936928 */
 static size_t count_utf8_code_points(const char *s) {
-    size_t count = 0;
-    while (*s) {
-        count += (*s++ & 0xC0) != 0x80;
-    }
-    return count;
+	size_t count = 0;
+	while (*s) {
+		count += (*s++ & 0xC0) != 0x80;
+	}
+	return count;
 }
 
 /* This function detects and configures direction, script and type of a word. */

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -5623,6 +5623,7 @@ xref_t txt_layout_xref(layout_t lay, int x, int y)
 			int hh,yy;
 			word = xref->words[i];
 			line = word->line;
+			int rtl = is_rtl(line->direction);
 			if (word->img_align)
 				continue;
 			if (y < line->y || y > line->y + line->h)
@@ -5630,11 +5631,17 @@ xref_t txt_layout_xref(layout_t lay, int x, int y)
 			yy = vertical_align(word, &hh);
 			if (y < line->y + yy || y > line->y + yy + hh)
 				continue;
-			if (x < line->x + word->x)
+
+			int x_begin = rtl? word->x_rtl: line->x+word->x;
+			int x_end = rtl? word->x_rtl+word->w: line->x + word->x + word->w;
+			if (x < x_begin)
 				continue;
-			if (x <= line->x + word->x + word->w)
+			if (x <= x_end)
 				return xref;
-			if (word->next && word->next->xref == xref && x < line->x + word->next->x + word->next->w) {
+			int next_x_end = 0;
+			if (word->next)
+				next_x_end = rtl? word->next->x_rtl: line->x + word->next->x + word->next->w;
+			if (word->next && word->next->xref == xref && x < next_x_end) {
 				yy = vertical_align(word->next, &hh);
 				if (y < line->y + yy || y > line->y + yy + hh)
 					continue;

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -17,7 +17,7 @@
 
 #include "utf8.h"
 
-static const u_int32_t offsetsFromUTF8[6] = {
+static const uint32_t offsetsFromUTF8[6] = {
     0x00000000UL, 0x00003080UL, 0x000E2080UL,
     0x03C82080UL, 0xFA082080UL, 0x82082080UL
 };
@@ -90,9 +90,9 @@ int u8_toucs(uint32_t *dest, int sz, const char *src, int srcsz)
 }
 
 /* reads the next utf-8 sequence out of a string, updating an index */
-u_int32_t u8_nextchar(const char *s, int *i)
+uint32_t u8_nextchar(const char *s, int *i)
 {
-    u_int32_t ch = 0;
+    uint32_t ch = 0;
     int sz = 0;
 
     do {

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -10,7 +10,7 @@ int u8_toucs(uint32_t *dest, int sz, const char *src, int srcsz);
 int u8_seqlen(const char *s);
 
 /* return next character, updating an index variable */
-u_int32_t u8_nextchar(const char *s, int *i);
+uint32_t u8_nextchar(const char *s, int *i);
 
 /* count the number of characters in a UTF-8 string */
 int u8_strlen(const char *s);


### PR DESCRIPTION
This PR contains the following fixes:

- Random lines had wrong directions due to wrong utf8 chars length
- Texts randomly and often upon first render were misaligned due to bad size calculation. Correct script and direction hat to be set before calling TTF_SizeUTF8 function.
- Menu renders correctly for Arabic script

Part of #76 
Edit add some pictures.

Bad render:
![Screenshot-20200901210754-802x639](https://user-images.githubusercontent.com/3101557/92043610-a1881880-ed7c-11ea-8caf-54f33c160ee0.png)

Good render:
![Screenshot-20200901210743-802x639](https://user-images.githubusercontent.com/3101557/92043632-abaa1700-ed7c-11ea-8d2d-d3ffa6f81a15.png)
