### PR TITLE
Retrieve attribute by name passed in argument

### DIFF
--- a/stead/stead3/ext/gui.lua
+++ b/stead/stead3/ext/gui.lua
@@ -77,7 +77,7 @@ local function get_bool(o, nam)
 		return o[nam]
 	end
 	if type(o[nam]) == 'function' then
-		return o:nam()
+		return o[nam](o)
 	end
 	return nil
 end


### PR DESCRIPTION
Before fix `nam` was taken as a literal field name, not as argument passed to function.

Original behavior caused error: 
```
Error: ./stead//stead3//ext/gui.lua:80: attempt to call method 'nam' (a string value)
stack traceback:
	./stead//stead3//ext/gui.lua:80: in function 'get_bool'
	./stead//stead3//ext/gui.lua:202: in function <./stead//stead3//ext/gui.lua:198>
```
when setting instead.nosave or instead.noautosave to a function