### PR TITLE
Не рисовать пиксель если его альфа = 0

### DIFF
--- a/src/instead_sprites.c
+++ b/src/instead_sprites.c
@@ -1109,10 +1109,10 @@ static __inline void pixel(unsigned char *s, unsigned char *d)
 	unsigned char a_dst = d[3];
 	if (a_src == 255 || a_dst == 0) {
 		memcpy(d, s, 4);
-	} else if (a_dst == 255) {
-		draw(s, d);
 	} else if (a_src == 0) {
 		/* nothing to do */
+	} else if (a_dst == 255) {
+		draw(s, d);
 	} else {
 		blend(s, d);
 	}


### PR DESCRIPTION
1) Решает проблему некорректного блендинга (рисование прозрачным пикселем поверх непрозрачного приводит к затемнению пикселей) 
2) Ускоряет код, поскольку рисование пикселем с альфой == 0 производиться никогда не будет 