### PR TITLE
Fix scaling error

### DIFF
--- a/src/SDL_rotozoom.c
+++ b/src/SDL_rotozoom.c
@@ -260,15 +260,15 @@ int _shrinkSurfaceY(SDL_Surface * src, SDL_Surface * dst, int factorx, int facto
 }
 
 int _greatestCommonDivisor(int n1, int n2) {
-    //Using Euclid's algorithm
-    int r = 1;
-    while (n2 > 0) {
-        r = n2;
-        n2 = n1 % n2;
-        n1 = r;
-    }
+	//Using Euclid's algorithm
+	int r = 1;
+	while (n2 > 0) {
+		r = n2;
+		n2 = n1 % n2;
+		n1 = r;
+	}
 
-    return r;
+	return r;
 }
 
 /*!
@@ -289,13 +289,13 @@ Assumes dst surface was allocated with the correct dimensions.
 int _zoomSurfaceRGBA(SDL_Surface * src, SDL_Surface * dst, int flipx, int flipy, int smooth)
 {
 	int x, y, sx, sy, ssx, ssy, *sax, *say, *csax, *csay, *salast, csx, csy, ex, ey, cx, cy, sstep, sstepx, sstepy;
-    /*
-     * Variables for applying scale factors
-     * dx, dy -- deltas to apply each fx, fy pixels
-     * mx, my -- Multiplier for source pixels (see below)
-     * fx, fy -- Multiplier for target pixels
-     * nxd, nyd -- next pixel to apply delta on
-     */
+	/*
+	 * Variables for applying scale factors
+	 * dx, dy -- deltas to apply each fx, fy pixels
+	 * mx, my -- Multiplier for source pixels (see below)
+	 * fx, fy -- Multiplier for target pixels
+	 * nxd, nyd -- next pixel to apply delta on
+	 */
 	int dx = 0, dy = 0, mx = 1, my = 1, fx = 0, fy = 0, nxd = 0, nyd = 0;
 	tColorRGBA *c00, *c01, *c10, *c11;
 	tColorRGBA *sp, *csp, *dp;
@@ -321,43 +321,43 @@ int _zoomSurfaceRGBA(SDL_Surface * src, SDL_Surface * dst, int flipx, int flipy,
 		sx = (int) (65536.0 * (float) spixelw / (float) (dst->w - 1));
 		sy = (int) (65536.0 * (float) spixelh / (float) (dst->h - 1));
 
-        if (dst->w > src->w) {
-            mx = _greatestCommonDivisor(dst->w - 1, spixelw);
-            fx = (dst->w - 1) / mx;
-            mx = spixelw / mx;
-        }
+		if (dst->w > src->w) {
+			mx = _greatestCommonDivisor(dst->w - 1, spixelw);
+			fx = (dst->w - 1) / mx;
+			mx = spixelw / mx;
+		}
 
-        if (dst->h > src->h) {
-            my = _greatestCommonDivisor(dst->h - 1, spixelh);
-            fy = (dst->h - 1) / my;
-            my = spixelh / my;
-        }
+		if (dst->h > src->h) {
+			my = _greatestCommonDivisor(dst->h - 1, spixelh);
+			fy = (dst->h - 1) / my;
+			my = spixelh / my;
+		}
 	} else {
 		sx = (int) (65536.0 * (float) (src->w) / (float) (dst->w));
 		sy = (int) (65536.0 * (float) (src->h) / (float) (dst->h));
 
-        if (dst->w > src->w) {
-            mx = _greatestCommonDivisor(dst->w, src->w);
-            fx = dst->w / mx;
-            mx = src->w / mx;
-        }
+		if (dst->w > src->w) {
+			mx = _greatestCommonDivisor(dst->w, src->w);
+			fx = dst->w / mx;
+			mx = src->w / mx;
+		}
 
-        if (dst->h > src->h) {
-            my = _greatestCommonDivisor(dst->h, src->h);
-            fy = dst->h / my;
-            my = src->h / my;
-        }
-    }
+		if (dst->h > src->h) {
+			my = _greatestCommonDivisor(dst->h, src->h);
+			fy = dst->h / my;
+			my = src->h / my;
+		}
+	}
 
-    if (dst->w > src->w) {
-        nxd = fx;
-        dx = 65536 * mx - sx * fx;
-    }
+	if (dst->w > src->w) {
+		nxd = fx;
+		dx = 65536 * mx - sx * fx;
+	}
 
-    if (dst->h > src->h) {
-        nyd = fy;
-        dy = 65536 * my - sy * fy;
-    }
+	if (dst->h > src->h) {
+		nyd = fy;
+		dy = 65536 * my - sy * fy;
+	}
 
 	/* Maximum scaled source size */
 	ssx = (src->w << 16) - 1;


### PR DESCRIPTION
Scaling in SDL_rotozoom.c is not precise, which is especially a problem for integer-scales, as in this case for some scales it could cause scaling artifacts visible as pixels not being scale uniformly and some of them being visibly larger than others.

To fix that, an approach to compensate this computation error is introduced. Every *f* pixels a delta *d* is added to calculated position.
Below is simplified calculation of f and d in order to provide uniform distribution
```
f = LCM(src_size, dst_size) / src_size -- number of destination pixels
m = LCM(src_size, dst_size) / dst_size -- number of source pixels
d = 1.0 * m - s * f, where s is reversed scale (src_size / dst_size)
```
LCM - Least common multiple

This approach is further optimized:
As `LCM(a, b) = a * b / GCD(a, b)`, where GCD -- is GreatestCommonDivisor
and we need LCM only divided by either of values a/b, we can calculate f and m as follows:
```
f = dst_size / GCD(src_size, dst_size) -- number of destination pixels
m = src_size / GCD(src_size, dst_size) -- number of source pixels
```

This algorithm is only applicable for scales > 1