### PR TITLE
gamepad triggers simulate mouse wheel up/down

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -249,6 +249,25 @@ static void gamepad_done(void)
 		SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
 }
 
+void gamepad_check_triggers(void)
+{
+	SDL_Event event;
+	memset(&event, 0, sizeof(event));
+	event.type = SDL_MOUSEWHEEL;
+
+	int trigger_left = 0, trigger_right = 0;
+	trigger_left = SDL_GameControllerGetAxis(gamepad, SDL_CONTROLLER_AXIS_TRIGGERLEFT);
+	trigger_right = SDL_GameControllerGetAxis(gamepad, SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
+
+	if (abs(trigger_left) > deadzone) {
+		event.wheel.y = 1;
+		SDL_PushEvent(&event);
+	} else if (abs(trigger_right) > deadzone) {
+		event.wheel.y = -1;
+		SDL_PushEvent(&event);
+	}
+}
+
 static int gamepad_timer_fn(int interval, void *p)
 {
 	SDL_Event event;
@@ -256,6 +275,8 @@ static int gamepad_timer_fn(int interval, void *p)
 
 	if (!gamepad)
 		return interval;
+
+	gamepad_check_triggers();
 
 	axis_x = SDL_GameControllerGetAxis(gamepad, SDL_CONTROLLER_AXIS_RIGHTX);
 	axis_y = SDL_GameControllerGetAxis(gamepad, SDL_CONTROLLER_AXIS_RIGHTY);


### PR DESCRIPTION
I tried playing with gamepad, but I missed the mouse scroll up/down feature.
I know you can press the dpad up/down, but you have to press/release/press/release
it many times to scroll up or down.
So I injected some code into `gamepad_timer_fn()` to check if triggers are pressed, and
send mouse wheel events if needed.